### PR TITLE
Fix install fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "jquery": "^2.1.4",
     "fs-plus": "^2.8.2",
     "path": "^0.12.7",
-    "mathjs": "^1.5.0",
+    "mathjs": "^1.5.0"
+  },
+  "package-deps": {
     "tool-bar": "^1.0.0"
   },
   "consumedServices": {

--- a/styles/cg-colors.less
+++ b/styles/cg-colors.less
@@ -1,4 +1,4 @@
-@import "../../cs-dark-syntax/styles/colors.less";
+@import "./colors.less";
 
 // background colors
 @cg-panel-bg-color							: @tool-panel-background-color;

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -1,0 +1,17 @@
+
+
+// @tool-panel-background-color;
+
+@gray_50        : #E7E7E7;
+@gray_100       : #D7D7D7;
+@gray_500       : #C7C7C7;
+@gray_600       : #B7B7B7;
+@gray_700       : #A7A7A7;
+@gray_800       : #979797;
+@gray_950       : #878787;
+
+
+@true_red_700   : #FF0000;
+@true_red_800   : #CD0303;
+@true_red_900   : #9F0000;
+


### PR DESCRIPTION
This fixes #5 by moving tool-bar to the atom package dependencies.   Also fixes issue with import of "../../cs-dark-syntax/styles/colors.less" which I could not find anywhere (I made up my own colors for the replacements)